### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: ruby
+rvm:
+  - 1.9.3
+script: "bundle exec rake test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: ruby
 rvm:
   - 1.9.3
-script: "bundle exec rake test"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source 'https://rubygems.org'
 
 gemspec
+
+group :test do
+    gem 'rake', '>= 0.9.2'
+end


### PR DESCRIPTION
Travis CI was developed for Ruby projects, so the configuration is arguably the easiest. Travic would run the `rake` command to test, but I thought it would be better to specify the full command for documentation's sake. The Gemfile was added because Travis will try to `bundle` the dependencies, which relies on a Gemfile. I tried to follow the [best practices](http://stackoverflow.com/questions/11301000/why-use-gemspec-gemfile-when-checking-for-dependencies).

For more, see the [Travis CI Getting Started Guide](http://about.travis-ci.org/docs/user/getting-started/) and [Ruby docs](http://about.travis-ci.org/docs/user/languages/ruby/).
