### PR TITLE
Make library flexible to support new api functions

### DIFF
--- a/demo/toopher_demo.rb
+++ b/demo/toopher_demo.rb
@@ -19,7 +19,9 @@ while secret.nil? or secret.empty?
   secret.chomp!
 end
 
-toopher = ToopherAPI.new(key, secret)
+url = ENV['TOOPHER_BASE_URL']
+puts 'using base url = ' + url
+toopher = ToopherAPI.new(key, secret, url)
 
 puts 'STEP 1: Pair device'
 puts 'enter pairing phrase:'

--- a/lib/toopher_api.rb
+++ b/lib/toopher_api.rb
@@ -61,11 +61,11 @@ class ToopherAPI
   # @param [String] user_name A human recognizable string which represents the user making the request (usually their username). This is displayed to the user on the mobile app when authenticating.
   #
   # @return [PairingStatus] Information about the pairing request
-  def pair(pairing_phrase, user_name)
+  def pair(pairing_phrase, user_name, options = {})
     return PairingStatus.new(post('pairings/create', {
       'pairing_phrase' => pairing_phrase,
       'user_name' => user_name
-    }))
+    }.merge(options)))
   end
 
   # Check on the status of a previous pairing request
@@ -84,13 +84,13 @@ class ToopherAPI
   # @param [String] action_name Optional action name, defaults to "log in" (displayed to the user)
   #
   # @return [AuthenticationStatus] Information about the authentication request
-  def authenticate(pairing_id, terminal_name, action_name = '')
+  def authenticate(pairing_id, terminal_name = '', action_name = '', options = {})
     parameters = {
       'pairing_id' => pairing_id,
       'terminal_name' => terminal_name
     }
     action_name.empty? or (parameters['action_name'] = action_name)
-    return AuthenticationStatus.new(post('authentication_requests/initiate', parameters))
+    return AuthenticationStatus.new(post('authentication_requests/initiate', parameters.merge(options)))
   end
 
   # Check on the status of a previous authentication request
@@ -146,11 +146,16 @@ class PairingStatus
   #   @return [String] The human recognizable user name associated with the given id.
   attr_accessor :user_name
 
+  # @!attribute raw
+  #   @return [hash] The raw data returned from the Toopher API
+  attr_accessor :raw
+
   def initialize(json_obj)
     @id = json_obj['id']
     @enabled = json_obj['enabled']
     @user_id = json_obj['user']['id']
     @user_name = json_obj['user']['name']
+    @raw = json_obj
   end
 end
 
@@ -185,6 +190,10 @@ class AuthenticationStatus
   #   @return [String] The human recognizable terminal name associated with the given id.
   attr_accessor :terminal_name
 
+  # @!attribute raw
+  #   @return [hash] The raw data returned from the Toopher API
+  attr_accessor :raw
+
   def initialize(json_obj)
     @id = json_obj['id']
     @pending = json_obj['pending']
@@ -193,5 +202,6 @@ class AuthenticationStatus
     @reason = json_obj['reason']
     @terminal_id = json_obj['terminal']['id']
     @terminal_name = json_obj['terminal']['name']
+    @raw = json_obj
   end
 end

--- a/test/test_toopher_api.rb
+++ b/test/test_toopher_api.rb
@@ -25,7 +25,7 @@ class TestToopher < Test::Unit::TestCase
   end
 
   def test_create_pairing_immediate_success()
-    stub_http_request(:post, "https://toopher-api.appspot.com/v1/pairings/create").
+    stub_http_request(:post, "https://toopher.test/v1/pairings/create").
       with(
 #        :headers => {
 #          'Authorization' => 'OAuth oauth_consumer_key="key",oauth_nonce="nonce",oauth_signature="%2FW9rUAFDuJTTBtfSxeQ%2FDxWpVQY%3D",oauth_signature_method="HMAC-SHA1",oauth_timestamp="0",oauth_version="1.0"'
@@ -37,7 +37,7 @@ class TestToopher < Test::Unit::TestCase
         :status => 200
       )
 
-      toopher = ToopherAPI.new('key', 'secret', {:nonce => 'nonce', :timestamp => '0' })
+      toopher = ToopherAPI.new('key', 'secret', {:nonce => 'nonce', :timestamp => '0' }, base_url="https://toopher.test/v1/")
       pairing = toopher.pair('immediate_pair', 'user')
       assert(pairing.id == '1', 'bad pairing id')
       assert(pairing.enabled == true, 'pairing not enabled')
@@ -47,7 +47,7 @@ class TestToopher < Test::Unit::TestCase
   end
 
   def test_create_pairing_with_optional_arg()
-    stub_http_request(:post, "https://toopher-api.appspot.com/v1/pairings/create").
+    stub_http_request(:post, "https://toopher.test/v1/pairings/create").
       with(
         :body => { 'pairing_phrase' => 'immediate_pair', 'user_name' => 'user' , 'test_param' => 'foo'}
       ).
@@ -56,7 +56,7 @@ class TestToopher < Test::Unit::TestCase
         :status => 200
       )
 
-      toopher = ToopherAPI.new('key', 'secret', {:nonce => 'nonce', :timestamp => '0' })
+      toopher = ToopherAPI.new('key', 'secret', {:nonce => 'nonce', :timestamp => '0' }, base_url="https://toopher.test/v1/")
       pairing = toopher.pair('immediate_pair', 'user', :test_param => 'foo')
       assert(pairing.id == '1', 'bad pairing id')
       assert(pairing.enabled == true, 'pairing not enabled')
@@ -65,18 +65,18 @@ class TestToopher < Test::Unit::TestCase
   end
 
   def test_get_pairing_status()
-    stub_http_request(:get, "https://toopher-api.appspot.com/v1/pairings/1").
+    stub_http_request(:get, "https://toopher.test/v1/pairings/1").
       to_return(
         :body => '{"id":"1","enabled":true,"user":{"id":"1","name":"paired user"}}',
         :status => 200
       )
-    stub_http_request(:get, "https://toopher-api.appspot.com/v1/pairings/2").
+    stub_http_request(:get, "https://toopher.test/v1/pairings/2").
       to_return(
         :body => '{"id":"2","enabled":false,"user":{"id":"2","name":"unpaired user"}}',
         :status => 200
       )
 
-      toopher = ToopherAPI.new('key', 'secret', {:nonce => 'nonce', :timestamp => '0' })
+      toopher = ToopherAPI.new('key', 'secret', {:nonce => 'nonce', :timestamp => '0' }, base_url="https://toopher.test/v1/")
       pairing = toopher.get_pairing_status('1')
       assert(pairing.id == '1', 'bad pairing id')
       assert(pairing.enabled == true, 'pairing not enabled')
@@ -91,7 +91,7 @@ class TestToopher < Test::Unit::TestCase
   end
 
   def test_create_authentication_with_no_action()
-    stub_http_request(:post, "https://toopher-api.appspot.com/v1/authentication_requests/initiate").
+    stub_http_request(:post, "https://toopher.test/v1/authentication_requests/initiate").
       with(
         :body => { 'pairing_id' => '1', 'terminal_name' => 'term name' }
       ).
@@ -100,7 +100,7 @@ class TestToopher < Test::Unit::TestCase
         :status => 200
       )
 
-    toopher = ToopherAPI.new('key', 'secret', {:nonce => 'nonce', :timestamp => '0' })
+    toopher = ToopherAPI.new('key', 'secret', {:nonce => 'nonce', :timestamp => '0' }, base_url="https://toopher.test/v1/")
     auth = toopher.authenticate('1', 'term name')
     assert(auth.id == '1', 'wrong auth id')
     assert(auth.pending == false, 'wrong auth pending')
@@ -112,7 +112,7 @@ class TestToopher < Test::Unit::TestCase
   end
 
   def test_create_authentication_with_optional_arg()
-    stub_http_request(:post, "https://toopher-api.appspot.com/v1/authentication_requests/initiate").
+    stub_http_request(:post, "https://toopher.test/v1/authentication_requests/initiate").
       with(
         :body => { 'pairing_id' => '1', 'terminal_name' => 'term name', 'test_param' => 'foo' }
       ).
@@ -121,7 +121,7 @@ class TestToopher < Test::Unit::TestCase
         :status => 200
       )
 
-    toopher = ToopherAPI.new('key', 'secret', {:nonce => 'nonce', :timestamp => '0' })
+    toopher = ToopherAPI.new('key', 'secret', {:nonce => 'nonce', :timestamp => '0' }, base_url="https://toopher.test/v1/")
     auth = toopher.authenticate('1', 'term name', '', {'test_param' => 'foo'})
     assert(auth.id == '1', 'wrong auth id')
     assert(auth.pending == false, 'wrong auth pending')
@@ -133,18 +133,18 @@ class TestToopher < Test::Unit::TestCase
   end
 
   def test_get_authentication_status()
-    stub_http_request(:get, "https://toopher-api.appspot.com/v1/authentication_requests/1").
+    stub_http_request(:get, "https://toopher.test/v1/authentication_requests/1").
       to_return(
         :body => '{"id":"1","pending":false,"granted":true,"automated":true,"reason":"some reason","terminal":{"id":"1","name":"term name"}}',
         :status => 200
       )
-    stub_http_request(:get, "https://toopher-api.appspot.com/v1/authentication_requests/2").
+    stub_http_request(:get, "https://toopher.test/v1/authentication_requests/2").
       to_return(
         :body => '{"id":"2","pending":true,"granted":false,"automated":false,"reason":"some other reason","terminal":{"id":"2","name":"another term name"}}',
         :status => 200
       )
 
-    toopher = ToopherAPI.new('key', 'secret', {:nonce => 'nonce', :timestamp => '0' })
+    toopher = ToopherAPI.new('key', 'secret', {:nonce => 'nonce', :timestamp => '0' }, base_url="https://toopher.test/v1/")
     auth = toopher.get_authentication_status('1')
     assert(auth.id == '1', 'wrong auth id')
     assert(auth.pending == false, 'wrong auth pending')
@@ -167,12 +167,12 @@ class TestToopher < Test::Unit::TestCase
   end
 
   def test_toopher_request_error()
-    stub_http_request(:get, "https://toopher-api.appspot.com/v1/authentication_requests/1").
+    stub_http_request(:get, "https://toopher.test/v1/authentication_requests/1").
       to_return(
         :body => '{"error_code":401,"error_message":"Not a valid OAuth signed request"}',
         :status => 401
       )
-    toopher = ToopherAPI.new('key', 'secret', {:nonce => 'nonce', :timestamp => '0' })
+    toopher = ToopherAPI.new('key', 'secret', {:nonce => 'nonce', :timestamp => '0' }, base_url="https://toopher.test/v1/")
     assert_raise ToopherApiError do
       auth = toopher.get_authentication_status('1')
     end


### PR DESCRIPTION
Adds `options` hash to `pair()` and `authenitcate()` to be able to pass arbitrary options to API methods.

Gives access to the raw API response in pairing and authentication status objects, through the `.raw` attribute

Allows callers to override `base_url`, updates demo to use this feature.
