### PR TITLE
Add version constant to library, bump version, and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ToopherAPI Ruby Client
 
+[![Build Status](https://travis-ci.org/toopher/toopher-ruby.png?branch=master)](https://travis-ci.org/toopher/toopher-ruby)
+
 #### Introduction
 ToopherAPI Ruby Client simplifies the task of interfacing with the Toopher API from Ruby code.  To use, just `gem install toopher_api` and you'll be ready to go.
 
@@ -81,4 +83,3 @@ To run all unit tests:
 $ rake test   # (or just 'rake')
 ```
 
-[![Build Status](https://travis-ci.org/toopher/toopher-ruby.png?branch=master)](https://travis-ci.org/toopher/toopher-ruby)

--- a/lib/toopher_api.rb
+++ b/lib/toopher_api.rb
@@ -33,6 +33,8 @@ end
 
 # Abstracts calls to the Toopher OAuth webservice
 class ToopherAPI
+  # Version of the library
+  VERSION = '1.0.6'
 
   # Default URL for the Toopher webservice API.  Can be overridden in the constructor if necessary.
   DEFAULT_BASE_URL = 'https://toopher-api.appspot.com/v1/'
@@ -115,6 +117,7 @@ class ToopherAPI
   end
 
   def request(url, req)
+    req['User-Agent'] = "Toopher-Ruby/#{VERSION}"
     http = Net::HTTP::new(url.host, url.port)
     http.use_ssl = url.port == 443
     req.oauth!(http, @oauth_consumer, nil, @oauth_options)

--- a/lib/toopher_api.rb
+++ b/lib/toopher_api.rb
@@ -117,7 +117,7 @@ class ToopherAPI
   end
 
   def request(url, req)
-    req['User-Agent'] = "Toopher-Ruby/#{VERSION}"
+    req['User-Agent'] = "Toopher-Ruby/#{VERSION} (Ruby #{RUBY_VERSION})"
     http = Net::HTTP::new(url.host, url.port)
     http.use_ssl = url.port == 443
     req.oauth!(http, @oauth_consumer, nil, @oauth_options)

--- a/test/test_toopher_api.rb
+++ b/test/test_toopher_api.rb
@@ -177,4 +177,15 @@ class TestToopher < Test::Unit::TestCase
       auth = toopher.get_authentication_status('1')
     end
   end
+
+  def test_version_string_exists()
+    assert(ToopherAPI::VERSION >= '1.0.6', 'version string does not exist')
+  end
+
+  def test_gemspec_version_matches_version_string()
+    version_string = File.open('toopher_api.gemspec').grep(/version/).first
+    gemspec_version = /version\s+=\s+'([\d.]+)'/.match(version_string).captures.first
+    assert(ToopherAPI::VERSION == gemspec_version, "version strings do not match: library = #{ToopherAPI::VERSION} and gemspec = #{gemspec_version}")
+  end
 end
+

--- a/test/test_toopher_api.rb
+++ b/test/test_toopher_api.rb
@@ -179,6 +179,10 @@ class TestToopher < Test::Unit::TestCase
   end
 
   def test_version_string_exists()
+    major, minor, patch = ToopherAPI::VERSION.split('.')
+    assert(major >= '1', 'version string (major level) is invalid')
+    assert(minor >= '0', 'version string (minor level) is invalid')
+    assert(patch >= '0', 'version string (patch level) is invalid')
     assert(ToopherAPI::VERSION >= '1.0.6', 'version string does not exist')
   end
 

--- a/toopher_api.gemspec
+++ b/toopher_api.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'toopher_api'
-  s.version       = '1.0.5'
+  s.version       = '1.0.6'
   s.date          = '2013-08-12'
   s.summary       = 'Interface to the toopher.com authentication api'
   s.description   = 'Synchronous interface to the toopher.com authentication api.'
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.email         = 'support@toopher.com'
   s.files         = ['Rakefile', 'lib/toopher_api.rb', 'test/test_toopher_api.rb', 'demo/toopher_demo.rb']
   s.homepage      = 'http://dev.toopher.com'
-  
+
   s.add_dependency('oauth', '>= 0.4.7')
   s.add_dependency('json', '>= 1.7.5')
 


### PR DESCRIPTION
This pull request adds a version constant to the library so users can check `ToopherAPI::VERSION`. I added a test to ensure that the constant exists and that the version of the library matches that of the gemspec.
